### PR TITLE
Convert ServiceContainer interface into a struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - Removed `MustGet` and `MustSet` methods from the `Container` interface. [#3](https://github.com/go-nacelle/service/pull/3)
 - Removed mocks package. [#6](https://github.com/go-nacelle/service/pull/6)
 
-
 ## [v1.0.2] - 2020-09-30
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@
 ### Changed
 
 - Change type of service keys from `string` to `interface{}`. [#4](https://github.com/go-nacelle/service/pull/4)
+- Replaced the `ServiceContainer` interface with `Container`, a struct with the same name and set of methods. [#7](https://github.com/go-nacelle/service/pull/7)
+- Renamed `NewServiceContainer` to `New`. [#7](https://github.com/go-nacelle/service/pull/7)
+- Renamed `Overlay` to `NewOverlay`. [#7](https://github.com/go-nacelle/service/pull/7)
 
 ### Removed
 
 - Removed `MustGet` and `MustSet` methods from the `Container` interface. [#3](https://github.com/go-nacelle/service/pull/3)
 - Removed mocks package. [#6](https://github.com/go-nacelle/service/pull/6)
+
 
 ## [v1.0.2] - 2020-09-30
 

--- a/inject.go
+++ b/inject.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 )
 
-// ServiceGetter is a subset of a ServiceContainer that only supports the
+// serviceGetter is a subset of a ServiceContainer that only supports the
 // retrieval of a registered service by name.
-type ServiceGetter interface {
+type serviceGetter interface {
 	// Get retrieves the service registered to the given key. It is an
 	// error for a service not to be registered to this key.
 	Get(key interface{}) (interface{}, error)
@@ -25,7 +25,7 @@ const (
 	optionalTag = "optional"
 )
 
-func inject(c ServiceGetter, obj interface{}, root *reflect.Value, baseIndexPath []int) (bool, error) {
+func inject(c serviceGetter, obj interface{}, root *reflect.Value, baseIndexPath []int) (bool, error) {
 	ov := reflect.ValueOf(obj)
 	oi := reflect.Indirect(ov)
 	ot := oi.Type()
@@ -98,7 +98,7 @@ func inject(c ServiceGetter, obj interface{}, root *reflect.Value, baseIndexPath
 	return hasTag, nil
 }
 
-func loadServiceField(container ServiceGetter, fieldType reflect.StructField, fieldValue reflect.Value, serviceTag, optionalTag string) error {
+func loadServiceField(container serviceGetter, fieldType reflect.StructField, fieldValue reflect.Value, serviceTag, optionalTag string) error {
 	if !fieldValue.IsValid() {
 		return fmt.Errorf("field '%s' is invalid", fieldType.Name)
 	}

--- a/overlay_container.go
+++ b/overlay_container.go
@@ -1,11 +1,11 @@
 package service
 
-type overlayContainer struct {
-	base     ServiceContainer
-	services map[interface{}]interface{}
+type Overlay struct {
+	*Container
+	overlayLayer map[interface{}]interface{}
 }
 
-// Overlay wraps the given service container with an immutable map of
+// NewOverlay wraps the given service container with an immutable map of
 // services. Calling Get on the resulting service container will return
 // a service from the overlay map, then will fall back to the wrapped
 // service container. Similarly, Inject will favor services from the
@@ -16,34 +16,28 @@ type overlayContainer struct {
 // with context for the current request or task to a short-lived handler.
 //
 // Calling Set will modify the wrapped container directly.
-func Overlay(base ServiceContainer, services map[interface{}]interface{}) ServiceContainer {
-	return &overlayContainer{
-		base:     base,
-		services: services,
+func NewOverlay(container *Container, services map[interface{}]interface{}) *Overlay {
+	return &Overlay{
+		Container:    container,
+		overlayLayer: services,
 	}
 }
 
 // Get retrieves the service registered to the given key. It is an
 // error for a service not to be registered to this key.
-func (c *overlayContainer) Get(key interface{}) (interface{}, error) {
-	if service, ok := c.services[key]; ok {
+func (c *Overlay) Get(key interface{}) (interface{}, error) {
+	if service, ok := c.overlayLayer[key]; ok {
 		return service, nil
 	}
 
-	return c.base.Get(key)
-}
-
-// Set registers a service with the given key. It is an error for
-// a service to already be registered to this key.
-func (c *overlayContainer) Set(key interface{}, service interface{}) error {
-	return c.base.Set(key, service)
+	return c.Container.Get(key)
 }
 
 // Inject will attempt to populate the given type with values from
 // the service container based on the value's struct tags. An error
 // may occur if a service has not been registered, a service has a
 // different type than expected, or struct tags are malformed.
-func (c *overlayContainer) Inject(obj interface{}) error {
+func (c *Overlay) Inject(obj interface{}) error {
 	_, err := inject(c, obj, nil, nil)
 	return err
 }

--- a/overlay_container_test.go
+++ b/overlay_container_test.go
@@ -12,12 +12,12 @@ func TestOverlayContainerGet(t *testing.T) {
 		val int
 	}
 
-	container := NewServiceContainer()
+	container := New()
 	container.Set("a", &T{10})
 	container.Set("b", &T{20})
 	container.Set("c", &T{30})
 
-	overlay := Overlay(container, map[interface{}]interface{}{
+	overlay := NewOverlay(container, map[interface{}]interface{}{
 		"a": &T{40},
 		"d": &T{50},
 	})
@@ -50,12 +50,12 @@ func TestOverlayContainerInject(t *testing.T) {
 		D *T1 `service:"d"`
 	}
 
-	container := NewServiceContainer()
+	container := New()
 	container.Set("a", &T1{10})
 	container.Set("b", &T1{20})
 	container.Set("c", &T1{30})
 
-	overlay := Overlay(container, map[interface{}]interface{}{
+	overlay := NewOverlay(container, map[interface{}]interface{}{
 		"a": &T1{40},
 		"d": &T1{50},
 	})


### PR DESCRIPTION
This is part of a greater effort to move interface declarations to the call sites instead of how they are used now (massive, parallel interface/structs at definition sites).