### PR TITLE
Add support for setting and retrieving a service container with contexts.

### DIFF
--- a/contexts.go
+++ b/contexts.go
@@ -6,7 +6,7 @@ type containerKeyType struct{}
 
 var containerKey = containerKeyType{}
 
-func WithContext(ctx context.Context, container *Container) context.Context {
+func WithContainer(ctx context.Context, container *Container) context.Context {
 	return context.WithValue(ctx, containerKey, container)
 }
 

--- a/contexts.go
+++ b/contexts.go
@@ -1,0 +1,18 @@
+package service
+
+import "context"
+
+type containerKeyType struct{}
+
+var containerKey = containerKeyType{}
+
+func WithContext(ctx context.Context, container *Container) context.Context {
+	return context.WithValue(ctx, containerKey, container)
+}
+
+func FromContext(ctx context.Context) *Container {
+	if v, ok := ctx.Value(containerKey).(*Container); ok {
+		return v
+	}
+	return nil
+}

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithAndFromContext(t *testing.T) {
+	type T1 struct{ val int }
+
+	t.Run("from context without value", func(t *testing.T) {
+		ctx := context.Background()
+		assert.Nil(t, FromContext(ctx))
+	})
+	t.Run("from context that has value", func(t *testing.T) {
+		container := New()
+		container.Set("a", &T1{10})
+
+		ctx := context.Background()
+		ctx = WithContext(ctx, container)
+
+		ctxContainer := FromContext(ctx)
+		require.NotNil(t, ctxContainer)
+
+		assertValue(t, ctxContainer, "a", &T1{10})
+	})
+}

--- a/contexts_test.go
+++ b/contexts_test.go
@@ -20,7 +20,7 @@ func TestWithAndFromContext(t *testing.T) {
 		container.Set("a", &T1{10})
 
 		ctx := context.Background()
-		ctx = WithContext(ctx, container)
+		ctx = WithContainer(ctx, container)
 
 		ctxContainer := FromContext(ctx)
 		require.NotNil(t, ctxContainer)


### PR DESCRIPTION
This adds support for getting and setting a `*Container` with a `context.Context` using the `WithContext` function to include the value in the context, and `FromContext` to retrieve it from the context.